### PR TITLE
Add codespell to prevent typos: config, workflow and some typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+# reference: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.codespellrc,./tdlm/tests/matlab_code
+# ignore-words-list = 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,21 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@
 name: Codespell
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 permissions:
   contents: read
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Temporally Delayed Linear Modeling (TDLM) is a method used to quantify the "sequ
 ```
 import tdlm
 
-preds = ... # get your prediction matrix somehwere
+preds = ... # get your prediction matrix somewhere
 tf = [[0, 1, 0], [ 0, 0, 1], [1, 0 , 0]]  # transition matrix
 sequenceness_fwd, sequenceness_bkw, * = tdlm.compute_1step(preds, tf)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TDLM-Python
 
+[![Codespell](https://github.com/skjerns/TDLM-Python/actions/workflows/codespell.yml/badge.svg)](https://github.com/skjerns/TDLM-Python/actions/workflows/codespell.yml)
+
 This repository provides a Python implementation of [TDLM](https://github.com/YunzheLiu/TDLM).
 
    \- Work-in-Progress -

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='tdlm-python',
       version='0.1',
       description='TDLM implementation for Python',
-      long_description='Temporally delayed linear modelling is a way to quantify sequential occurences of events in time series and biosignals such as EEG or MEG',
+      long_description='Temporally delayed linear modelling is a way to quantify sequential occurrences of events in time series and biosignals such as EEG or MEG',
       long_description_content_type="text/markdown",
       url='http://github.com/skjerns/TDLM-Python',
       author='skjerns',

--- a/tdlm/tests/matlab_code/Simulate_Replay_LongerLength.m
+++ b/tdlm/tests/matlab_code/Simulate_Replay_LongerLength.m
@@ -43,7 +43,7 @@ parfor iSj = 1:nSubj
     
     %% generate the true patterns
     commonPattern = randn(1,nSensors);    
-    patterns =  repmat(commonPattern, [8 1]) + randn(8, nSensors); % this induce correlations between classifers, for seperate representation: randn(8, nSensors);
+    patterns =  repmat(commonPattern, [8 1]) + randn(8, nSensors); % this induce correlations between classifiers, for separate representation: randn(8, nSensors);
    
     %% make training data
     trainingData = 4*randn(nNullExamples+8*nTrainPerStim, nSensors) + [zeros(nNullExamples,nSensors); ...

--- a/tdlm/tests/matlab_code/distinguishable_colors.m
+++ b/tdlm/tests/matlab_code/distinguishable_colors.m
@@ -61,7 +61,7 @@ function colors = distinguishable_colors(n_colors,bg,func)
     bg = [1 1 1];  % default white background
   else
     if iscell(bg)
-      % User specified a list of colors as a cell aray
+      % User specified a list of colors as a cell array
       bgc = bg;
       for i = 1:length(bgc)
 	bgc{i} = parsecolor(bgc{i});

--- a/tdlm/tests/matlab_code/matlab_funcs.py
+++ b/tdlm/tests/matlab_code/matlab_funcs.py
@@ -93,7 +93,7 @@ def autoconvert(func):
     try:
         import matlab
     except Exception:
-        logging.error("Matlab for Python isnt installed in this distribution")
+        logging.error("Matlab for Python isn't installed in this distribution")
         return None
     matlab.float64 = matlab.double
     matlab.float32 = matlab.double

--- a/tdlm/tests/matlab_code/rodent replay/README.md
+++ b/tdlm/tests/matlab_code/rodent replay/README.md
@@ -4,6 +4,6 @@ analysis code for hippocampal spiking data during sleep using TDLM, data from Ó
 ## multi-scale TDLM for a range of replay speed
 ``` RodentReplay_onlySeq_All.m ```
 
-## explictly modelling time in multi-scale TDLM
+## explicitly modelling time in multi-scale TDLM
 
 ``` RodentReplay_SleepTime_All.m ```

--- a/tdlm/tests/matlab_code/rodent replay/TDLM_multiscale.m
+++ b/tdlm/tests/matlab_code/rodent replay/TDLM_multiscale.m
@@ -1,8 +1,8 @@
 function [Seq_integrate, Seq_separate]=TDLM_multiscale(X, rateMaps, binSize, nshuf, nlags)
 
 % INPUT
-% X          - candinate replay evernts, ntime (concatenated) * ncells
-% rateMaps   - raw rate maps, ncells * npos (this inlcudes both inbound and outbound)  
+% X          - candidate replay evernts, ntime (concatenated) * ncells
+% rateMaps   - raw rate maps, ncells * npos (this includes both inbound and outbound)  
 % binSize    - temporal bin size, in s, so 0.001 -> 1ms
 % nShuf      - number of nShufs
 % nlags      - number of time lags to test
@@ -13,8 +13,8 @@ function [Seq_integrate, Seq_separate]=TDLM_multiscale(X, rateMaps, binSize, nsh
 
 ratemap=[];
 
-%% scale and corrsponding time lags to average (hard coded for now)
-scales=[24,12,8,6]; % numnber of states, higher number indciates higher spatial resolution
+%% scale and corresponding time lags to average (hard coded for now)
+scales=[24,12,8,6]; % number of states, higher number indicates higher spatial resolution
 ntimes={[1:100];[2:2:200];[3:3:300];[4:4:400]}; % corresponding time lags (range) of interest: 1-100 ms
 
 %% make the rate map in different scales - for marginalize over in-, out-bound

--- a/tdlm/tests/matlab_code/rodent replay/TDLM_multiscale_modelT.m
+++ b/tdlm/tests/matlab_code/rodent replay/TDLM_multiscale_modelT.m
@@ -1,8 +1,8 @@
 function [Seq_integrate, Seq_separate, Time_integrate, Time_separate]=TDLM_multiscale_modelT(X, rateMaps, binSize, nshuf, nlags, TOI)
 
 % INPUT
-% X          - candinate replay evernts, ntime (concatenated) * ncells
-% rateMaps   - raw rate maps, ncells * npos (this inlcudes both inbound and outbound)  
+% X          - candidate replay evernts, ntime (concatenated) * ncells
+% rateMaps   - raw rate maps, ncells * npos (this includes both inbound and outbound)  
 % binSize    - temporal bin size, in s, so 0.001 -> 1ms
 % nShuf      - number of nShufs
 % nlags      - number of time lags to test
@@ -14,8 +14,8 @@ function [Seq_integrate, Seq_separate, Time_integrate, Time_separate]=TDLM_multi
 
 ratemap=[];
 
-%% scale and corrsponding time lags to average (hard coded for now)
-scales=[24,12,8,6]; % numnber of states, higher number indciates higher spatial resolution
+%% scale and corresponding time lags to average (hard coded for now)
+scales=[24,12,8,6]; % number of states, higher number indicates higher spatial resolution
 ntimes={TOI;TOI*2;TOI*3;TOI*4}; % corresponding time lags of interest, this is for 2 ms, transiting 2 cm, i.e., 1000cm/s
 
 %% make the rate map in different scales - for marginalize over in-, out-bound

--- a/tdlm/tests/matlab_code/rodent replay/barwitherr.m
+++ b/tdlm/tests/matlab_code/rodent replay/barwitherr.m
@@ -5,7 +5,7 @@
 %   parameter "errors" passed first.
 %
 %   Parameters:
-%   errors - the errors to be plotted (extra dimension used if assymetric)
+%   errors - the errors to be plotted (extra dimension used if asymmetric)
 %   varargin - parameters as passed to conventional bar plot
 %   See bar and errorbar documentation for more details.
 %
@@ -50,13 +50,13 @@
 %   24/02/2011  Martina F. Callaghan    Created
 %   12/08/2011  Martina F. Callaghan    Updated for random x-values   
 %   24/10/2011  Martina F. Callaghan    Updated for asymmetric errors
-%   15/11/2011  Martina F. Callaghan    Fixed bug for assymetric errors &
+%   15/11/2011  Martina F. Callaghan    Fixed bug for asymmetric errors &
 %                                       vector plots
 %   14/06/2013  Martina F. Callaghan    Returning handle as recommended by
 %                                       Eric (see submission comments)
 %   08/07/2013  Martina F. Callaghan    Only return handle if requested.
 %   18/07/2013  Martina F. Callaghan    Bug fix for single group data that 
-%                                       allows assymetric errors.
+%                                       allows asymmetric errors.
 %                                       Also removed dot from display as
 %                                       per Charles Colin comment. The 
 %                                       handle can be returned to control
@@ -92,7 +92,7 @@ else
 end
 
 % If an extra dimension is supplied for the errors then they are
-% assymetric split out into upper and lower:
+% asymmetric split out into upper and lower:
 if ndims(errors) == ndims(values)+1
     lowerErrors = errors(:,:,1);
     upperErrors = errors(:,:,2);
@@ -105,7 +105,7 @@ else
 end
 
     
-% Check that the size of "errors" corresponsds to the size of the y-values.
+% Check that the size of "errors" corresponds to the size of the y-values.
 % Arbitrarily using lower errors as indicative.
 if any(size(values) ~= size(lowerErrors))
     error('The values and errors have to be the same length')

--- a/tdlm/tests/matlab_code/rodent replay/placeBayes.m
+++ b/tdlm/tests/matlab_code/rodent replay/placeBayes.m
@@ -1,7 +1,7 @@
 function Pr = placeBayes(X, rateMaps, binsize)
 
 % INPUT
-% X - candiate event to be decoded, ntime * ncells, each entry is the spike counts
+% X - candidate event to be decoded, ntime * ncells, each entry is the spike counts
 % rateMaps - rate maps, ncells * npos
 % binSize, in the unit of s, this is tau in the equation
 

--- a/tdlm/tests/test_matlab_compatibility.py
+++ b/tdlm/tests/test_matlab_compatibility.py
@@ -33,7 +33,7 @@ def uperms_matlab(*args, **kwargs):
 
 class TestMatlab(unittest.TestCase):
 
-    def test_uperms(selfs):
+    def test_uperms(self):
         """"call uperms function from MATLAB for testing"""
         print('Starting matlab engine')
 

--- a/tdlm/tests/test_matlab_compatibility.py
+++ b/tdlm/tests/test_matlab_compatibility.py
@@ -41,7 +41,7 @@ class TestMatlab(unittest.TestCase):
         if not 'matlab_code' in ml.cd():
             ml.cd('./matlab_code')        
 
-        #TODO test doesnt work, but I have no time to debug 
+        #TODO test doesn't work, but I have no time to debug 
         repetitions = 15  # no k set
         with patch('numpy.random.permutation', lambda x: np.array(ml.randperm(x)).squeeze()-1): 
             for i in tqdm(list(range(1, repetitions)), desc='Running tests 1/2'):
@@ -161,7 +161,7 @@ class TestMatlab(unittest.TestCase):
         """test whether the results of Simulate_Replay.m are the same
         
         this only tests the actual sequenceness calculation. it makes
-        no sense to compare the predictions themselve, as matlab and python
+        no sense to compare the predictions themselves, as matlab and python
         implement Lasso regression differently. However, uperms is slightly
         differently implemented, so we need to monkey patch that.
         """


### PR DESCRIPTION
I let codespell ignore `/tdlm/tests/matlab_code` (bunch of typos there), assuming that this is just archived legacy code.

Only "typo" that remains is:

```bash
$ codespell       
./tdlm/tests/test_matlab_compatibility.py:36: selfs ==> self
```

We could let codespell ignore it or change? I don't yet know what the implications for the code might be @skjerns.

